### PR TITLE
Change PCLint command line arguments

### DIFF
--- a/tools/External Tools.xml
+++ b/tools/External Tools.xml
@@ -72,8 +72,8 @@
   <tool name="PCLint" showInMainMenu="false" showInEditor="false" showInProject="false" showInSearchPopup="false" disabled="false" useConsole="true" showConsoleOnStdOut="false" showConsoleOnStdErr="true" synchronizeAfterRun="true">
     <exec>
       <option name="COMMAND" value="ament_pclint" />
-      <option name="PARAMETERS" value="$FilePath$" />
-      <option name="WORKING_DIRECTORY" value="$FileDir$" />
+      <option name="PARAMETERS" value="--package-root $CMakeCurrentBuildDir$/.. $FilePath$" />
+      <option name="WORKING_DIRECTORY" value="$CMakeCurrentBuildDir$/.." />
     </exec>
     <filter>
       <option name="NAME" value="No name" />


### PR DESCRIPTION
This change will force the developers to fix the violations in headers unless they put a `.ament_pclint-ignore-headers` in the package root.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/ros2_clion_style/4)
<!-- Reviewable:end -->
