### PR TITLE
Include RTI ConnextMicro path for ament_pclint

### DIFF
--- a/tools/External Tools.xml
+++ b/tools/External Tools.xml
@@ -72,7 +72,7 @@
   <tool name="PCLint" showInMainMenu="false" showInEditor="false" showInProject="false" showInSearchPopup="false" disabled="false" useConsole="true" showConsoleOnStdOut="false" showConsoleOnStdErr="true" synchronizeAfterRun="true">
     <exec>
       <option name="COMMAND" value="ament_pclint" />
-      <option name="PARAMETERS" value="--package-root $CMakeCurrentBuildDir$/.. $FilePath$" />
+      <option name="PARAMETERS" value="--package-root $CMakeCurrentBuildDir$/.. --include-directories /opt/rti_connext_micro/include -- $FilePath$" />
       <option name="WORKING_DIRECTORY" value="$CMakeCurrentBuildDir$/.." />
     </exec>
     <filter>


### PR DESCRIPTION
This PR add `--include-directories /opt/rti_connext_micro/include` to the `ament_pclint` external tool, so that the header files will be found by `ament_pclint`

@sumanth-nirmal This should fix the issue you had

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/ros2_clion_style/7)
<!-- Reviewable:end -->
