### PR TITLE
Add external tools entry for running PCLint at the package level

### DIFF
--- a/tools/External Tools.xml
+++ b/tools/External Tools.xml
@@ -81,6 +81,18 @@
       <option name="REGEXP" value=".*$FILE_PATH$:$LINE$\].*" />
     </filter>
   </tool>
+  <tool name="PCLint (entire package)" description="Run PCLint on the currently loaded package" showInMainMenu="false" showInEditor="false" showInProject="false" showInSearchPopup="false" disabled="false" useConsole="true" showConsoleOnStdOut="false" showConsoleOnStdErr="false" synchronizeAfterRun="true">
+    <exec>
+      <option name="COMMAND" value="ctest" />
+      <option name="PARAMETERS" value="-V -L pclint" />
+      <option name="WORKING_DIRECTORY" value="$CMakeCurrentBuildDir$" />
+    </exec>
+    <filter>
+      <option name="NAME" value="" />
+      <option name="DESCRIPTION" value="" />
+      <option name="REGEXP" value=".*$FILE_PATH$:$LINE$\].*" />
+    </filter>
+  </tool>
   <tool name="Doxygen" showInMainMenu="false" showInEditor="false" showInProject="false" showInSearchPopup="false" disabled="false" useConsole="true" showConsoleOnStdOut="false" showConsoleOnStdErr="false" synchronizeAfterRun="true">
     <exec>
       <option name="COMMAND" value="_apex_clion_doxygen" />


### PR DESCRIPTION
The current PCLint button/external tool only works on the file/folder level and has a fixed configuration which makes it difficult to use for packages that require more extensive PCLint configuration (for example defines, includes, only linting a subset of files, etc). 

By going through ctest to invoke the PCLint "test", PCLint will be run however it is configured in the package CMakeLists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/ros2_clion_style/10)
<!-- Reviewable:end -->
