### PR TITLE
Invoke Axivion via CTest

### DIFF
--- a/tools/External Tools.xml
+++ b/tools/External Tools.xml
@@ -100,16 +100,16 @@
       <option name="WORKING_DIRECTORY" value="$ProjectFileDir$/.." />
     </exec>
   </tool>
-  <tool name="Axivion" showInMainMenu="false" showInEditor="false" showInProject="false" showInSearchPopup="false" disabled="false" useConsole="true" showConsoleOnStdOut="false" showConsoleOnStdErr="true" synchronizeAfterRun="true">
+  <tool name="Axivion" description="Run Axivion on currently loaded package" showInMainMenu="false" showInEditor="false" showInProject="false" showInSearchPopup="false" disabled="false" useConsole="true" showConsoleOnStdOut="false" showConsoleOnStdErr="false" synchronizeAfterRun="true">
     <exec>
-      <option name="COMMAND" value="ament_axivion" />
-      <option name="PARAMETERS" value="--package-root $CMakeCurrentBuildDir$/.. --compiler-definitions APEX_CERT DDS_RTI_CONNEXT_MICRO --include-directories /opt/rti_connext_micro/include --treat-as-package" />
-      <option name="WORKING_DIRECTORY" value="$CMakeCurrentBuildDir$/.." />
+      <option name="COMMAND" value="ctest" />
+      <option name="PARAMETERS" value="-V -L axivion" />
+      <option name="WORKING_DIRECTORY" value="$CMakeCurrentBuildDir$" />
     </exec>
     <filter>
-      <option name="NAME" value="No name" />
+      <option name="NAME" />
       <option name="DESCRIPTION" />
-      <option name="REGEXP" value=".*$FILE_PATH$:$LINE$\].*" />
+      <option name="REGEXP" value=".*$FILE_PATH$:$LINE$.*" />
     </filter>
   </tool>
 </toolSet>


### PR DESCRIPTION
This MR changes the invocation of axivion, using `ctest` instead of `ament_axivion` directly. The main advantage is that with `ctest`, relevant compiler definitions (e.g. APEX_CERT) and include directories will be added automatically based on the loaded build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/ros2_clion_style/15)
<!-- Reviewable:end -->
