### PR TITLE
Add ApexAI keymap based on Visual Studio

### DIFF
--- a/_linux/keymap.xml
+++ b/_linux/keymap.xml
@@ -1,5 +1,5 @@
 <application>
   <component name="KeymapManager">
-    <active_keymap name="Visual Studio" />
+    <active_keymap name="Visual Studio ApexAI" />
   </component>
 </application>

--- a/keymaps/Visual Studio ApexAI.xml
+++ b/keymaps/Visual Studio ApexAI.xml
@@ -1,0 +1,33 @@
+<keymap version="1" name="Visual Studio ApexAI" parent="Visual Studio">
+  <action id="Back">
+    <keyboard-shortcut first-keystroke="ctrl alt left" />
+  </action>
+  <action id="CommentByLineComment">
+    <keyboard-shortcut first-keystroke="ctrl slash" />
+  </action>
+  <action id="EditorSelectWord">
+    <keyboard-shortcut first-keystroke="ctrl w" />
+  </action>
+  <action id="EditorUnSelectWord">
+    <keyboard-shortcut first-keystroke="shift ctrl w" />
+  </action>
+  <action id="FindUsages">
+    <keyboard-shortcut first-keystroke="shift f12" />
+    <keyboard-shortcut first-keystroke="shift alt f7" />
+  </action>
+  <action id="Forward">
+    <keyboard-shortcut first-keystroke="ctrl alt right" />
+  </action>
+  <action id="GotoFile">
+    <keyboard-shortcut first-keystroke="shift ctrl n" />
+  </action>
+  <action id="Graph.ActualSize">
+    <keyboard-shortcut first-keystroke="ctrl divide" />
+  </action>
+  <action id="Images.Editor.ActualSize">
+    <keyboard-shortcut first-keystroke="ctrl divide" />
+  </action>
+  <action id="RenameElement">
+    <keyboard-shortcut first-keystroke="shift f6" />
+  </action>
+</keymap>


### PR DESCRIPTION
After update to the CLion to the 2020.2 version, JetBrains changed keymap for essential operations in Visual Studio keymap scheme which we were using by default.
This MR will add new keymap "Visual Studio ApexAI" with old keymap and set it by default in settings to be consistent and to be independent from future occasional changes from upstream.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/ros2_clion_style/17)
<!-- Reviewable:end -->
