### PR TITLE
Use dejavu font by default

### DIFF
--- a/_linux/keymap.xml
+++ b/_linux/keymap.xml
@@ -1,5 +1,5 @@
 <application>
   <component name="KeymapManager">
-    <active_keymap name="Visual Studio" />
+    <active_keymap name="Visual Studio ApexAI" />
   </component>
 </application>

--- a/editor.xml
+++ b/editor.xml
@@ -1,8 +1,10 @@
 <application>
   <component name="DefaultFont">
     <option name="FONT_SIZE" value="14" />
+    <option name="FONT_FAMILY" value="DejaVu Sans Mono" />
   </component>
   <component name="EditorSettings">
     <option name="SOFT_WRAP_FILE_MASKS" value="*.md; *.txt; *.rst; *.adoc" />
+    <option name="IS_WHEEL_FONTCHANGE_ENABLED" value="true" />
   </component>
 </application>

--- a/keymaps/Visual Studio ApexAI.xml
+++ b/keymaps/Visual Studio ApexAI.xml
@@ -1,0 +1,33 @@
+<keymap version="1" name="Visual Studio ApexAI" parent="Visual Studio">
+  <action id="Back">
+    <keyboard-shortcut first-keystroke="ctrl alt left" />
+  </action>
+  <action id="CommentByLineComment">
+    <keyboard-shortcut first-keystroke="ctrl slash" />
+  </action>
+  <action id="EditorSelectWord">
+    <keyboard-shortcut first-keystroke="ctrl w" />
+  </action>
+  <action id="EditorUnSelectWord">
+    <keyboard-shortcut first-keystroke="shift ctrl w" />
+  </action>
+  <action id="FindUsages">
+    <keyboard-shortcut first-keystroke="shift f12" />
+    <keyboard-shortcut first-keystroke="shift alt f7" />
+  </action>
+  <action id="Forward">
+    <keyboard-shortcut first-keystroke="ctrl alt right" />
+  </action>
+  <action id="GotoFile">
+    <keyboard-shortcut first-keystroke="shift ctrl n" />
+  </action>
+  <action id="Graph.ActualSize">
+    <keyboard-shortcut first-keystroke="ctrl divide" />
+  </action>
+  <action id="Images.Editor.ActualSize">
+    <keyboard-shortcut first-keystroke="ctrl divide" />
+  </action>
+  <action id="RenameElement">
+    <keyboard-shortcut first-keystroke="shift f6" />
+  </action>
+</keymap>


### PR DESCRIPTION
After update CLION to the version 2020.2 and upper Jetbrain start using another font rather than it was it was before, which has different size and looks different.
This MR will setup DejaVu font for using by default as it was before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/ros2_clion_style/18)
<!-- Reviewable:end -->
