### PR TITLE
Update CLion settings to be compliant with new versions

### DIFF
--- a/advancedSettings.xml
+++ b/advancedSettings.xml
@@ -1,0 +1,10 @@
+<application>
+  <component name="AdvancedSettings">
+    <option name="settings">
+      <map>
+        <entry key="show.diff.as.editor.tab" value="false" />
+        <entry key="terminal.buffer.max.lines.count" value="10000" />
+      </map>
+    </option>
+  </component>
+</application>

--- a/codestyles/Default.xml
+++ b/codestyles/Default.xml
@@ -11,36 +11,59 @@
     <option name="INDENT_NAMESPACE_MEMBERS" value="0" />
     <option name="INDENT_C_STRUCT_MEMBERS" value="2" />
     <option name="INDENT_CLASS_MEMBERS" value="2" />
+    <option name="INDENT_VISIBILITY_KEYWORDS" value="1" />
     <option name="INDENT_INSIDE_CODE_BLOCK" value="2" />
+    <option name="KEEP_STRUCTURES_IN_ONE_LINE" value="true" />
+    <option name="KEEP_CASE_EXPRESSIONS_IN_ONE_LINE" value="true" />
+    <option name="FUNCTION_NON_TOP_AFTER_RETURN_TYPE_WRAP" value="0" />
+    <option name="FUNCTION_TOP_AFTER_RETURN_TYPE_WRAP" value="0" />
+    <option name="FUNCTION_PARAMETERS_WRAP" value="5" />
+    <option name="FUNCTION_CALL_ARGUMENTS_WRAP" value="5" />
+    <option name="TEMPLATE_CALL_ARGUMENTS_WRAP" value="5" />
+    <option name="TEMPLATE_CALL_ARGUMENTS_ALIGN_MULTILINE" value="true" />
+    <option name="CLASS_CONSTRUCTOR_INIT_LIST_WRAP" value="5" />
+    <option name="ALIGN_INIT_LIST_IN_COLUMNS" value="false" />
+    <option name="SPACE_BEFORE_PROTOCOLS_BRACKETS" value="false" />
+    <option name="SPACE_BEFORE_COLON_IN_FOREACH" value="true" />
+    <option name="KEEP_BLANK_LINES_BEFORE_END" value="1" />
     <option name="ADD_BRIEF_TAG" value="true" />
     <option name="TAG_PREFIX_OF_BLOCK_COMMENT" value="BACK_SLASH" />
+    <option name="HEADER_GUARD_STYLE_PATTERN" value="${PROJECT_NAME}_${PROJECT_REL_PATH}_${FILE_NAME}_${EXT}_" />
   </Objective-C>
   <Objective-C-extensions>
     <option name="TAG_PREFIX_OF_BLOCK_COMMENT" value="BACK_SLASH" />
-    <file>
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Typedef" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Enum" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Constant" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Global" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Struct" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="FunctionPredecl" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Function" />
-    </file>
-    <class>
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Property" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Synthesize" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InitMethod" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="StaticMethod" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InstanceMethod" />
-      <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="DeallocMethod" />
-    </class>
-    <extensions>
-      <pair source="cpp" header="hpp" />
-      <pair source="c" header="h" />
-    </extensions>
+    <rules>
+      <rule entity="MACRO" visibility="ANY" specifier="ANY" prefix="" style="SCREAMING_SNAKE_CASE" suffix="" />
+      <rule entity="NAMESPACE" visibility="ANY" specifier="ANY" prefix="" style="SNAKE_CASE" suffix="" />
+      <rule entity="CLASS,ENUM,UNION,TYPEDEF" visibility="ANY" specifier="ANY" prefix="" style="PASCAL_CASE" suffix="" />
+      <rule entity="CLASS_MEMBER_FIELD" visibility="ANY" specifier="ANY" prefix="" style="SNAKE_CASE" suffix="_" />
+      <rule entity="STRUCT_MEMBER_FIELD" visibility="ANY" specifier="ANY" prefix="" style="SNAKE_CASE" suffix="" />
+      <rule entity="ENUMERATOR" visibility="ANY" specifier="ANY" prefix="" style="SCREAMING_SNAKE_CASE" suffix="" />
+      <rule entity="GLOBAL_FUNCTION,CLASS_MEMBER_FUNCTION,STRUCT_MEMBER_FUNCTION" visibility="ANY" specifier="ANY" prefix="" style="PASCAL_CASE" suffix="" />
+      <rule entity="PARAMETER,LOCAL_VARIABLE" visibility="ANY" specifier="ANY" prefix="" style="SNAKE_CASE" suffix="" />
+      <rule entity="GLOBAL_VARIABLE,LOCAL_VARIABLE" visibility="ANY" specifier="CONST" prefix="k" style="PASCAL_CASE" suffix="" />
+    </rules>
   </Objective-C-extensions>
+  <Objective-C-extensions>
+    <option name="TAG_PREFIX_OF_BLOCK_COMMENT" value="BACK_SLASH" />
+    <rules>
+      <rule entity="MACRO" visibility="ANY" specifier="ANY" prefix="" style="SCREAMING_SNAKE_CASE" suffix="" />
+      <rule entity="NAMESPACE" visibility="ANY" specifier="ANY" prefix="" style="SNAKE_CASE" suffix="" />
+      <rule entity="CLASS,ENUM,UNION,TYPEDEF" visibility="ANY" specifier="ANY" prefix="" style="PASCAL_CASE" suffix="" />
+      <rule entity="CLASS_MEMBER_FIELD" visibility="ANY" specifier="ANY" prefix="" style="SNAKE_CASE" suffix="_" />
+      <rule entity="STRUCT_MEMBER_FIELD" visibility="ANY" specifier="ANY" prefix="" style="SNAKE_CASE" suffix="" />
+      <rule entity="ENUMERATOR" visibility="ANY" specifier="ANY" prefix="" style="SCREAMING_SNAKE_CASE" suffix="" />
+      <rule entity="GLOBAL_FUNCTION,CLASS_MEMBER_FUNCTION,STRUCT_MEMBER_FUNCTION" visibility="ANY" specifier="ANY" prefix="" style="PASCAL_CASE" suffix="" />
+      <rule entity="PARAMETER,LOCAL_VARIABLE" visibility="ANY" specifier="ANY" prefix="" style="SNAKE_CASE" suffix="" />
+      <rule entity="GLOBAL_VARIABLE,LOCAL_VARIABLE" visibility="ANY" specifier="CONST" prefix="k" style="PASCAL_CASE" suffix="" />
+    </rules>
+  </Objective-C-extensions>
+  <files>
+    <extensions>
+      <pair source="cpp" header="hpp" fileNamingConvention="NONE" />
+      <pair source="c" header="h" fileNamingConvention="NONE" />
+    </extensions>
+  </files>
   <codeStyleSettings language="CMake">
     <indentOptions>
       <option name="INDENT_SIZE" value="2" />
@@ -49,11 +72,22 @@
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="ObjectiveC">
+    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
+    <option name="BLANK_LINES_BEFORE_IMPORTS" value="0" />
+    <option name="BLANK_LINES_AFTER_IMPORTS" value="0" />
+    <option name="BLANK_LINES_AROUND_CLASS" value="0" />
+    <option name="BLANK_LINES_AROUND_METHOD" value="0" />
+    <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0" />
+    <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="false" />
     <option name="SPACE_AFTER_TYPE_CAST" value="false" />
+    <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+    <option name="FOR_STATEMENT_WRAP" value="1" />
+    <option name="ASSIGNMENT_WRAP" value="1" />
     <indentOptions>
       <option name="INDENT_SIZE" value="2" />
       <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      <option name="TAB_SIZE" value="2" />
     </indentOptions>
   </codeStyleSettings>
 </code_scheme>

--- a/diff.xml
+++ b/diff.xml
@@ -1,4 +1,7 @@
 <application>
+  <component name="ExternalDiffSettings">
+    <option name="MIGRATE_OLD_SETTINGS" value="true" />
+  </component>
   <component name="TextDiffSettings">
     <option name="SHARED_SETTINGS">
       <SharedSettings>

--- a/editor-font.xml
+++ b/editor-font.xml
@@ -1,0 +1,9 @@
+<application>
+  <component name="DefaultFont">
+    <option name="VERSION" value="1" />
+    <option name="FONT_SIZE" value="15" />
+    <option name="FONT_SIZE_2D" value="15.0" />
+    <option name="FONT_FAMILY" value="DejaVu Sans Mono" />
+    <option name="FONT_REGULAR_SUB_FAMILY" value="Book" />
+  </component>
+</application>

--- a/editor.xml
+++ b/editor.xml
@@ -3,5 +3,6 @@
     <option name="SOFT_WRAP_FILE_MASKS" value="*.md; *.txt; *.rst; *.adoc" />
     <option name="IS_WHEEL_FONTCHANGE_ENABLED" value="true" />
     <option name="IS_WHEEL_FONTCHANGE_PERSISTENT" value="true" />
+    <option name="KEEP_TRAILING_SPACE_ON_CARET_LINE" value="false" />
   </component>
 </application>

--- a/editor.xml
+++ b/editor.xml
@@ -6,5 +6,6 @@
   <component name="EditorSettings">
     <option name="SOFT_WRAP_FILE_MASKS" value="*.md; *.txt; *.rst; *.adoc" />
     <option name="IS_WHEEL_FONTCHANGE_ENABLED" value="true" />
+    <option name="IS_WHEEL_FONTCHANGE_PERSISTENT" value="true" />
   </component>
 </application>

--- a/editor.xml
+++ b/editor.xml
@@ -1,8 +1,4 @@
 <application>
-  <component name="DefaultFont">
-    <option name="FONT_SIZE" value="14" />
-    <option name="FONT_FAMILY" value="DejaVu Sans Mono" />
-  </component>
   <component name="EditorSettings">
     <option name="SOFT_WRAP_FILE_MASKS" value="*.md; *.txt; *.rst; *.adoc" />
     <option name="IS_WHEEL_FONTCHANGE_ENABLED" value="true" />

--- a/filetypes.xml
+++ b/filetypes.xml
@@ -1,7 +1,16 @@
 <application>
-  <component name="FileTypeManager" version="17">
+  <component name="FileTypeManager" version="18">
     <extensionMap>
+      <mapping pattern="AMENT_IGNORE" type="AUTO_DETECTED" />
+      <mapping pattern="launch_ros" type="AUTO_DETECTED" />
+      <mapping pattern="ros2topic" type="AUTO_DETECTED" />
+      <mapping pattern="Doxyfile" type="AUTO_DETECTED" />
+      <mapping ext="msg" type="PLAIN_TEXT" />
       <mapping ext="idl" type="PLAIN_TEXT" />
+      <mapping ext="srv" type="PLAIN_TEXT" />
+      <mapping ext="db3-shm" type="SQL" />
+      <mapping ext="db3-wal" type="SQL" />
+      <mapping ext="em" type="BuildoutCfg" />
     </extensionMap>
   </component>
 </application>

--- a/find.xml
+++ b/find.xml
@@ -28,5 +28,7 @@
     <mask>*.c</mask>
     <mask>*.hpp</mask>
     <mask>*.cpp</mask>
+    <mask>*.txt</mask>
+    <mask>*.py</mask>
   </component>
 </application>

--- a/grazie_global.xml
+++ b/grazie_global.xml
@@ -1,0 +1,13 @@
+<application>
+  <component name="GraziConfig">
+    <option name="checkingContext">
+      <CheckingContext>
+        <option name="enabledLanguages">
+          <set>
+            <option value="Doxygen" />
+          </set>
+        </option>
+      </CheckingContext>
+    </option>
+  </component>
+</application>

--- a/ide.general.xml
+++ b/ide.general.xml
@@ -5,5 +5,15 @@
   <component name="Registry">
     <entry key="debugger.watches.in.variables" value="false" />
     <entry key="terminal.buffer.max.lines.count" value="10000" />
+    <entry key="ide.images.show.chessboard" value="true" />
+    <entry key="debugger.valueTooltipAutoShowOnSelection" value="true" />
+  </component>
+  <component name="StatusBar">
+    <option name="widgets">
+      <map>
+        <entry key="ClangdMemory" value="true" />
+        <entry key="Memory" value="true" />
+      </map>
+    </option>
   </component>
 </application>

--- a/laf.xml
+++ b/laf.xml
@@ -1,0 +1,5 @@
+<application>
+  <component name="LafManager" autodetect="false">
+    <laf class-name="com.intellij.ide.ui.laf.darcula.DarculaLaf" />
+  </component>
+</application>

--- a/settingsSync.xml
+++ b/settingsSync.xml
@@ -1,0 +1,5 @@
+<application>
+  <component name="SettingsSyncSettings">
+    <option name="migrationFromOldStorageChecked" value="true" />
+  </component>
+</application>

--- a/ui.lnf.xml
+++ b/ui.lnf.xml
@@ -1,5 +1,7 @@
 <application>
   <component name="UISettings">
+    <option name="compactTreeIndents" value="true" />
+    <option name="EDITOR_TAB_LIMIT" value="15" />
     <option name="OVERRIDE_NONIDEA_LAF_FONTS" value="true" />
     <option name="SHOW_MAIN_TOOLBAR" value="true" />
   </component>


### PR DESCRIPTION
We are going to update CLion in ADE image to the latest 2022.3 https://gitlab.apex.ai/ApexAI/grand_central/-/issues/14318.
Although new versions of CLion has a bit changes in configuration files. Some sections was migrated and some was added as new.
I also scrubbed my personal CLion settings and selected those one which I think would be useful to have for everyone by default.

List of changes:
- Add laf.xml - settings for LafManager
  - LafManager uses in look and feel components for provisioned `Darcula` theme scheme.
- Update diff.xml with new `ExternalDiffSettings` default value
~~- Delete `filetypes.xml` since there are no custom settings~~
- Enable spell checker for Doxygen
- Move settings for editor font to the editor-font.xml
  - In new versions of CLion settings relevant to the editor's font migrated from editor.xml to their own editor-font.xml file.
- Don't show diff as editor tab and increase max lines in terminal to 10000
- Apply settings to change font in all editor windows by mouse scroll
- Use compact indentation when showing "trees" and increase active number of tabs (opened files) to 15
- Show memory using by CLion in status bar.
  - Also added settings to automatically show value of the variable on selection as a tool-tip
- Add missing default value for Axivion action int ApexAI toolbar
- Apply google code style for `CodeStyleSettings`
  - Rationale:
    ROS2 and ApexAI coding style based on google coding stile
---
Update:
- Disable KEEP_TRAILING_SPACE_ON_CARET_LINE for our doc linter compliance
- Updates in filetypes.xml
  - Add ROS2 specific filetypes
- Add *.txt and *.py in find dialog
- Enable settings migration from old storage

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/ros2_clion_style/25)
<!-- Reviewable:end -->
