### PR TITLE
Exclude bazel specific files from CLion code parser

### DIFF
--- a/filetypes.xml
+++ b/filetypes.xml
@@ -1,5 +1,6 @@
 <application>
   <component name="FileTypeManager" version="18">
+    <ignoreFiles list="*.pyc;*.pyo;*.rbc;*.yarb;*~;.DS_Store;.git;.hg;.svn;CVS;__pycache__;_svn;bazel-bin;bazel-install;bazel-src;bazel-testlogs;vssver.scc;vssver2.scc" />
     <extensionMap>
       <mapping pattern="AMENT_IGNORE" type="AUTO_DETECTED" />
       <mapping pattern="launch_ros" type="AUTO_DETECTED" />


### PR DESCRIPTION
This PR is a follow up from our internal chat conversation.
```
Tobias Stark: Question to other CLion users: When I use the find-in-file command, on a project level, CLion also searches through the bazel directories (bazel-src, etc.). Is there any way to exclusde these from the search by default?
--
  | Carlos San Vicente: Same here, I had to exclude the bazel directories because Clion was not responding when building. You can ignore them in Editor->File Types->Ignored Files and Folders. Then add the following folders: bazel-bin, bazel-install, bazel-src, bazel-testlogs
  | Carlos San Vicente: Now CLion doesn't block
  | Carlos San Vicente: We may want to add this to the default CLion settings @Kilian Funk @Karl Wallner
```
Signed-off-by: Michael Orlov <michael.orlov@apex.ai>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/ros2_clion_style/29)
<!-- Reviewable:end -->
