### PR TITLE
Update static code analysis tools settings

### DIFF
--- a/editor.xml
+++ b/editor.xml
@@ -1,5 +1,7 @@
 <application>
+  <component name="DaemonCodeAnalyzerSettings" profile="ApexAI Default" />
   <component name="EditorSettings">
+    <option name="USE_SOFT_WRAPS" value="CONSOLE" />
     <option name="SOFT_WRAP_FILE_MASKS" value="*.md; *.txt; *.rst; *.adoc" />
     <option name="IS_WHEEL_FONTCHANGE_ENABLED" value="true" />
     <option name="IS_WHEEL_FONTCHANGE_PERSISTENT" value="true" />

--- a/inspection/ApexAI Default.xml
+++ b/inspection/ApexAI Default.xml
@@ -1,0 +1,17 @@
+<profile version="1.0">
+  <option name="myName" value="ApexAI Default" />
+  <inspection_tool class="ClangTidy" enabled="true" level="WARNING" enabled_by_default="false">
+    <scope name="Project Source Files" level="WARNING" enabled="true" />
+  </inspection_tool>
+  <inspection_tool class="Clazy" enabled="false" level="WARNING" enabled_by_default="false" />
+  <inspection_tool class="Misra" enabled="true" level="WARNING" enabled_by_default="false">
+    <scope name="Project Source Files" level="WARNING" enabled="true" />
+  </inspection_tool>
+  <inspection_tool class="OCUnusedConcept" enabled="false" level="WARNING" enabled_by_default="false" />
+  <inspection_tool class="OCUnusedGlobalDeclaration" enabled="false" level="WARNING" enabled_by_default="false" />
+  <inspection_tool class="OCUnusedIncludeDirective" enabled="false" level="WARNING" enabled_by_default="false" />
+  <inspection_tool class="OCUnusedMacro" enabled="false" level="WARNING" enabled_by_default="false" />
+  <inspection_tool class="OCUnusedStruct" enabled="false" level="WARNING" enabled_by_default="false" />
+  <inspection_tool class="OCUnusedTemplateParameter" enabled="false" level="WARNING" enabled_by_default="false" />
+  <inspection_tool class="OCUnusedTypeAlias" enabled="false" level="WARNING" enabled_by_default="false" />
+</profile>

--- a/inspection/Default.xml
+++ b/inspection/Default.xml
@@ -1,0 +1,3 @@
+<profile version="1.0">
+  <option name="myName" value="Default" />
+</profile>


### PR DESCRIPTION
- Disabled Clazy by default (This is analysis tool for QT)
- Disabled check for unused code. Rationale:
  - A lot of false positives,
  - Affects performance,
  - We don't care too much about it on practice.
- Enabled ClangTidy for `Project Source Files` only. Rationale:
  - performance optimization
- Enabled MISRA rules for `Project Source Files` only. Rationale:
  - We do need to check misra rules for certified code.
  - It will be handy for MISRA violations fixes and justification.

![image](https://user-images.githubusercontent.com/7294722/210917279-84fa41a2-1727-4923-9be2-e44f4200b46d.png)


Signed-off-by: Michael Orlov <michael.orlov@apex.ai>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/ros2_clion_style/30)
<!-- Reviewable:end -->
